### PR TITLE
Edit for !status (The word active was split incorrectly)

### DIFF
--- a/basicBot.js
+++ b/basicBot.js
@@ -3176,8 +3176,8 @@
                         */
 
                         // This is a more efficient solution
-                        if (msg.length > 241){
-                            var split = msg.match(/.{1,241}/g);
+                        if (msg.length > 238){
+                            var split = msg.match(/.{1,238}/g);
                             for (var i = 0; i < split.length; i++) {
                                 var func = function(index) {
                                     setTimeout(function() {


### PR DESCRIPTION
Fixed so "Active" is now one line, instead of being split into "ac" and "tive"